### PR TITLE
SDK rename npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 -->
 
-[![Version](https://img.shields.io/npm/v/@adobe/aem-headless-client.svg)](https://npmjs.org/package/@adobe/aem-headless-client)
-[![Downloads/week](https://img.shields.io/npm/dw/@adobe/aem-headless-client.svg)](https://npmjs.org/package/@adobe/aem-headless-client)
-[![Build Status](https://github.com/adobe/aem-headless-client-sdk/workflows/Node.js%20CI/badge.svg?branch=main)](https://github.com/adobe/aem-headless-client-sdk/actions)
+[![Version](https://img.shields.io/npm/v/@adobe/aem-headless-client-js.svg)](https://npmjs.org/package/@adobe/aem-headless-client-js)
+[![Downloads/week](https://img.shields.io/npm/dw/@adobe/aem-headless-client-js.svg)](https://npmjs.org/package/@adobe/aem-headless-client-js)
+[![Build Status](https://github.com/adobe/aem-headless-client-js/workflows/Node.js%20CI/badge.svg?branch=main)](https://github.com/adobe/aem-headless-client-js/actions)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # AEM Headless Client for JavaScript
@@ -20,7 +20,7 @@ governing permissions and limitations under the License.
 ## Installation
 
 ```bash
-$ npm install @adobe/aem-headless-client
+$ npm install @adobe/aem-headless-client-js
 ```
 
 ## Usage
@@ -28,7 +28,7 @@ $ npm install @adobe/aem-headless-client
 ### Create AEMHeadless client
 
 ```javascript
-const AEMHeadless = require('@adobe/aem-headless-client');
+const AEMHeadless = require('@adobe/aem-headless-client-js');
 ```
 Configure SDK with Host and Auth data (if needed)
 ```javascript
@@ -101,7 +101,7 @@ If `auth` is not defined, Authorization header will not be set
 SDK contains helper function to get Auth token from credentials config file
 
 ```javascript
-const { getToken } = require('@adobe/aem-headless-sdk')
+const { getToken } = require('@adobe/aem-headless-client-js')
 (async () => {
     const { accessToken, type, expires } = await getToken('path/to/service-config.json')
     const sdkNode = new AEMHeadless('content/graphql/endpoint.gql', AEM_HOST_URI, accessToken)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "bugs": {
-    "url": "https://github.com/adobe/aem-headless-client-sdk/issues"
+    "url": "https://github.com/adobe/aem-headless-client-js/issues"
   },
   "bundleDependencies": false,
   "dependencies": {
@@ -27,12 +27,12 @@
     "jsdoc-to-markdown": "^6.0.1",
     "stdout-stderr": "^0.1.13"
   },
-  "homepage": "https://github.com/adobe/aem-headless-client-sdk",
+  "homepage": "https://github.com/adobe/aem-headless-client-js",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "browser": "src/browser.js",
-  "name": "@adobe/aem-headless-client",
-  "repository": "https://github.com/adobe/aem-headless-client-sdk",
+  "name": "@adobe/aem-headless-client-js",
+  "repository": "https://github.com/adobe/aem-headless-client-js",
   "scripts": {
     "docs": "jsdoc2md -t ./docs/readme_template.md src/main.js > api-reference.md",
     "lint": "eslint src test",


### PR DESCRIPTION
Package renamed.
After merging we need to publish it to NPM and old package should be marked as deprecated.