### PR TITLE
Feature/12 rename methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ aemHeadlessClient.postQuery(queryString)
   .then(data => console.log(data))
   .catch(e => console.error(e.toJSON()))
 
-aemHeadlessClient.listQueries()
+aemHeadlessClient.listPersistedQueries()
    .then(data => console.log(data))
    .catch(e => console.error(e.toJSON()))
 
-aemHeadlessClient.saveQuery(queryString, 'wknd/persist-query-name')
+aemHeadlessClient.persistQuery(queryString, 'wknd/persist-query-name')
    .then(data => console.log(data))
    .catch(e => console.error(e.toJSON()))
 
-aemHeadlessClient.getQuery('wknd/persist-query-name')
+aemHeadlessClient.runPersistedQuery('wknd/persist-query-name')
    .then(data => console.log(data))
    .catch(e => console.error(e.toJSON()))
 ```
@@ -70,20 +70,20 @@ aemHeadlessClient.getQuery('wknd/persist-query-name')
     
     let list
     try {
-        list = aemHeadlessClient.listQueries()
+        list = aemHeadlessClient.listPersistedQueries()
     } catch (e) {
         console.error(e.toJSON())
     }
 
     try {
-        aemHeadlessClient.saveQuery(queryString, 'wknd/persist-query-name')
+        aemHeadlessClient.persistQuery(queryString, 'wknd/persist-query-name')
     } catch (e) {
         console.error(e.toJSON())
     }
     
     let getData
     try {
-        getData = aemHeadlessClient.getQuery('wknd/persist-query-name')
+        getData = aemHeadlessClient.runPersistedQuery('wknd/persist-query-name')
     } catch (e) {
         console.error(e.toJSON())
     }
@@ -103,11 +103,11 @@ If `auth` is not defined, Authorization header will not be set
 SDK contains helper function to get Auth token from credentials config file
 
 ```javascript
-const { getToken } = require('@adobe/aem-headless-client-js')
+const {getToken} = require('@adobe/aem-headless-client-js')
 (async () => {
-    const { accessToken, type, expires } = await getToken('path/to/service-config.json')
+    const {accessToken, type, expires} = await getToken('path/to/service-config.json')
     const sdkNode = new AEMHeadless('content/graphql/endpoint.gql', AEM_HOST_URI, accessToken)
-    const data = sdkNode.postQuery(queryString)
+    const data = sdkNode.runQuery(queryString)
 })()
 ```
 ## API Reference

--- a/README.md
+++ b/README.md
@@ -34,9 +34,17 @@ const AEMHeadless = require('@adobe/aem-headless-client-js');
 ```
 Configure SDK with Host and Auth data (if needed)
 ```javascript
-const aemHeadlessClient = new AEMHeadless('<graphql_endpoint>', '<aem_host>', '<aem_token>' || ['<aem_user>', '<aem_pass>'])
+const aemHeadlessClient = new AEMHeadless({
+    serviceURL: '<aem_host>',
+    endpoint: '<graphql_endpoint>',
+    auth: '<aem_token>' || ['<aem_user>', '<aem_pass>']
+})
 // Eg:
-const aemHeadlessClient = new AEMHeadless('content/graphql/endpoint.gql', AEM_HOST_URI, AEM_TOKEN || [AEM_USER, AEM_PASS])
+const aemHeadlessClient = new AEMHeadless({
+    serviceURL: AEM_HOST_URI,
+    endpoint: 'content/graphql/endpoint.gql',
+    auth: [AEM_USER, AEM_PASS]
+})
 ```
 ### Use AEMHeadless client 
 

--- a/api-reference.md
+++ b/api-reference.md
@@ -21,23 +21,26 @@ with GraphQL endpoint, GraphQL host and auth if needed
 **Kind**: global class  
 
 * [AEMHeadless](#AEMHeadless)
-    * [new AEMHeadless(endpoint, [host], [auth])](#new_AEMHeadless_new)
+    * [new AEMHeadless(config)](#new_AEMHeadless_new)
     * [.runQuery(query, [options])](#AEMHeadless+runQuery) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.persistQuery(query, endpoint, [options])](#AEMHeadless+persistQuery) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.persistQuery(query, path, [options])](#AEMHeadless+persistQuery) ⇒ <code>Promise.&lt;any&gt;</code>
     * [.listPersistedQueries([options])](#AEMHeadless+listPersistedQueries) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.runPersistedQuery(endpoint, [options])](#AEMHeadless+runPersistedQuery) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.runPersistedQuery(path, [options])](#AEMHeadless+runPersistedQuery) ⇒ <code>Promise.&lt;any&gt;</code>
 
 <a name="new_AEMHeadless_new"></a>
 
-### new AEMHeadless(endpoint, [host], [auth])
+### new AEMHeadless(config)
 Constructor.
+If param is a string, it's treated as AEM server URL, default GraphQL endpoint is used.
+For granular params, use config object
 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| endpoint | <code>string</code> | GraphQL endpoint |
-| [host] | <code>string</code> | GraphQL host, if not defined absolute endpoint path will be passed to fetch |
-| [auth] | <code>string</code> \| <code>Array</code> | Bearer token string or [user,pass] pair array |
+| config | <code>object</code> \| <code>string</code> | Configuration object, or AEM server URL string |
+| [config.serviceURL] | <code>string</code> | AEM server URL |
+| [config.endpoint] | <code>string</code> | GraphQL endpoint, full URL or absolute path |
+| [config.auth] | <code>string</code> \| <code>Array</code> | Bearer token string or [user,pass] pair array |
 
 <a name="AEMHeadless+runQuery"></a>
 
@@ -54,7 +57,7 @@ Returns a Promise that resolves with a POST request JSON data.
 
 <a name="AEMHeadless+persistQuery"></a>
 
-### aemHeadless.persistQuery(query, endpoint, [options]) ⇒ <code>Promise.&lt;any&gt;</code>
+### aemHeadless.persistQuery(query, path, [options]) ⇒ <code>Promise.&lt;any&gt;</code>
 Returns a Promise that resolves with a PUT request JSON data.
 
 **Kind**: instance method of [<code>AEMHeadless</code>](#AEMHeadless)  
@@ -63,7 +66,7 @@ Returns a Promise that resolves with a PUT request JSON data.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | query | <code>string</code> |  | the query string |
-| endpoint | <code>string</code> |  | AEM path to save query, format: configuration_name/endpoint_name |
+| path | <code>string</code> |  | AEM path to save query, format: configuration_name/endpoint_name |
 | [options] | <code>object</code> | <code>{}</code> | additional PUT request options |
 
 <a name="AEMHeadless+listPersistedQueries"></a>
@@ -80,7 +83,7 @@ Returns a Promise that resolves with a GET request JSON data.
 
 <a name="AEMHeadless+runPersistedQuery"></a>
 
-### aemHeadless.runPersistedQuery(endpoint, [options]) ⇒ <code>Promise.&lt;any&gt;</code>
+### aemHeadless.runPersistedQuery(path, [options]) ⇒ <code>Promise.&lt;any&gt;</code>
 Returns a Promise that resolves with a GET request JSON data.
 
 **Kind**: instance method of [<code>AEMHeadless</code>](#AEMHeadless)  
@@ -88,6 +91,6 @@ Returns a Promise that resolves with a GET request JSON data.
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| endpoint | <code>string</code> |  | AEM path for persisted query, format: configuration_name/endpoint_name |
+| path | <code>string</code> |  | AEM path for persisted query, format: configuration_name/endpoint_name |
 | [options] | <code>object</code> | <code>{}</code> | additional GET request options |
 

--- a/api-reference.md
+++ b/api-reference.md
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 -->
-# API Reference
+# AEM HEADLESS SDK API Reference
 
 <a name="AEMHeadless"></a>
 
@@ -22,10 +22,10 @@ with GraphQL endpoint, GraphQL host and auth if needed
 
 * [AEMHeadless](#AEMHeadless)
     * [new AEMHeadless(endpoint, [host], [auth])](#new_AEMHeadless_new)
-    * [.postQuery(query, [options])](#AEMHeadless+postQuery) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.saveQuery(query, endpoint, [options])](#AEMHeadless+saveQuery) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.listQueries([options])](#AEMHeadless+listQueries) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.getQuery(endpoint, [options])](#AEMHeadless+getQuery) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.runQuery(query, [options])](#AEMHeadless+runQuery) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.persistQuery(query, endpoint, [options])](#AEMHeadless+persistQuery) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.listPersistedQueries([options])](#AEMHeadless+listPersistedQueries) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.runPersistedQuery(endpoint, [options])](#AEMHeadless+runPersistedQuery) ⇒ <code>Promise.&lt;any&gt;</code>
 
 <a name="new_AEMHeadless_new"></a>
 
@@ -39,9 +39,9 @@ Constructor.
 | [host] | <code>string</code> | GraphQL host, if not defined absolute endpoint path will be passed to fetch |
 | [auth] | <code>string</code> \| <code>Array</code> | Bearer token string or [user,pass] pair array |
 
-<a name="AEMHeadless+postQuery"></a>
+<a name="AEMHeadless+runQuery"></a>
 
-### aemHeadless.postQuery(query, [options]) ⇒ <code>Promise.&lt;any&gt;</code>
+### aemHeadless.runQuery(query, [options]) ⇒ <code>Promise.&lt;any&gt;</code>
 Returns a Promise that resolves with a POST request JSON data.
 
 **Kind**: instance method of [<code>AEMHeadless</code>](#AEMHeadless)  
@@ -52,9 +52,9 @@ Returns a Promise that resolves with a POST request JSON data.
 | query | <code>string</code> |  | the query string |
 | [options] | <code>object</code> | <code>{}</code> | additional POST request options |
 
-<a name="AEMHeadless+saveQuery"></a>
+<a name="AEMHeadless+persistQuery"></a>
 
-### aemHeadless.saveQuery(query, endpoint, [options]) ⇒ <code>Promise.&lt;any&gt;</code>
+### aemHeadless.persistQuery(query, endpoint, [options]) ⇒ <code>Promise.&lt;any&gt;</code>
 Returns a Promise that resolves with a PUT request JSON data.
 
 **Kind**: instance method of [<code>AEMHeadless</code>](#AEMHeadless)  
@@ -66,9 +66,9 @@ Returns a Promise that resolves with a PUT request JSON data.
 | endpoint | <code>string</code> |  | AEM path to save query, format: configuration_name/endpoint_name |
 | [options] | <code>object</code> | <code>{}</code> | additional PUT request options |
 
-<a name="AEMHeadless+listQueries"></a>
+<a name="AEMHeadless+listPersistedQueries"></a>
 
-### aemHeadless.listQueries([options]) ⇒ <code>Promise.&lt;any&gt;</code>
+### aemHeadless.listPersistedQueries([options]) ⇒ <code>Promise.&lt;any&gt;</code>
 Returns a Promise that resolves with a GET request JSON data.
 
 **Kind**: instance method of [<code>AEMHeadless</code>](#AEMHeadless)  
@@ -78,9 +78,9 @@ Returns a Promise that resolves with a GET request JSON data.
 | --- | --- | --- | --- |
 | [options] | <code>object</code> | <code>{}</code> | additional GET request options |
 
-<a name="AEMHeadless+getQuery"></a>
+<a name="AEMHeadless+runPersistedQuery"></a>
 
-### aemHeadless.getQuery(endpoint, [options]) ⇒ <code>Promise.&lt;any&gt;</code>
+### aemHeadless.runPersistedQuery(endpoint, [options]) ⇒ <code>Promise.&lt;any&gt;</code>
 Returns a Promise that resolves with a GET request JSON data.
 
 **Kind**: instance method of [<code>AEMHeadless</code>](#AEMHeadless)  

--- a/api-reference.md
+++ b/api-reference.md
@@ -39,7 +39,7 @@ For granular params, use config object
 | --- | --- | --- |
 | config | <code>object</code> \| <code>string</code> | Configuration object, or AEM server URL string |
 | [config.serviceURL] | <code>string</code> | AEM server URL |
-| [config.endpoint] | <code>string</code> | GraphQL endpoint, full URL or absolute path |
+| [config.endpoint] | <code>string</code> | GraphQL endpoint |
 | [config.auth] | <code>string</code> \| <code>Array</code> | Bearer token string or [user,pass] pair array |
 
 <a name="AEMHeadless+runQuery"></a>

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -30,8 +30,36 @@ const queryString = `
 let sdk = {}
 const persistedName = 'wknd/persist-query-name'
 
-beforeAll(() => {
-  sdk = new AEMHeadless(AEM_GRAPHQL_ENDPOINT || 'content/graphql/endpoint.gql', AEM_HOST_URI, AEM_TOKEN || [AEM_USER, AEM_PASS])
+beforeEach(() => {
+  sdk = new AEMHeadless({
+    serviceURL: AEM_HOST_URI,
+    endpoint: AEM_GRAPHQL_ENDPOINT,
+    auth: AEM_TOKEN || [AEM_USER, AEM_PASS]
+  })
+})
+
+test('e2e test sdk valid params', () => {
+  // check success response
+  const config = { serviceURL: AEM_HOST_URI, auth: AEM_TOKEN || [AEM_USER, AEM_PASS] }
+  sdk = new AEMHeadless(config)
+  expect(sdk).toHaveProperty('serviceURL')
+  expect(sdk).toHaveProperty('endpoint')
+})
+
+test('e2e test sdk missing params', () => {
+  // check success response
+  const config = {}
+  sdk = new AEMHeadless(config)
+  expect(sdk).toHaveProperty('serviceURL')
+  expect(sdk).toHaveProperty('endpoint')
+})
+
+test('e2e test sdk missing param serviceURL', () => {
+  // check success response
+  const config = { endpoint: 'test' }
+  sdk = new AEMHeadless(config)
+  expect(sdk).toHaveProperty('serviceURL')
+  expect(sdk).toHaveProperty('endpoint')
 })
 
 test('e2e test persistQuery API Success', () => {
@@ -47,7 +75,7 @@ test('e2e test persistQuery API Error', () => {
 })
 
 test('e2e test listPersistedQueries API Success', () => {
-  const promise = sdk.listQueries()
+  const promise = sdk.listPersistedQueries()
   return expect(promise).resolves.toBeTruthy()
 })
 

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -34,43 +34,43 @@ beforeAll(() => {
   sdk = new AEMHeadless(AEM_GRAPHQL_ENDPOINT || 'content/graphql/endpoint.gql', AEM_HOST_URI, AEM_TOKEN || [AEM_USER, AEM_PASS])
 })
 
-test('e2e test saveQuery API Success', () => {
+test('e2e test persistQuery API Success', () => {
   // check success response
-  const promise = sdk.saveQuery(queryString, `${persistedName}-${Date.now()}`)
+  const promise = sdk.persistQuery(queryString, `${persistedName}-${Date.now()}`)
   return expect(promise).resolves.toBeTruthy()
 })
 
-test('e2e test saveQuery API Error', () => {
+test('e2e test persistQuery API Error', () => {
   // check error response
-  const promise = sdk.saveQuery(queryString, persistedName)
+  const promise = sdk.persistQuery(queryString, persistedName)
   return expect(promise).rejects.toThrow()
 })
 
-test('e2e test listQueries API Success', () => {
+test('e2e test listPersistedQueries API Success', () => {
   const promise = sdk.listQueries()
   return expect(promise).resolves.toBeTruthy()
 })
 
-test('e2e test postQuery API Success', () => {
+test('e2e test runQuery API Success', () => {
   // check success response
-  const promise = sdk.postQuery(queryString)
+  const promise = sdk.runQuery(queryString)
   return expect(promise).resolves.toBeTruthy()
 })
 
-test('e2e test postQuery API Error', () => {
+test('e2e test runQuery API Error', () => {
   // check error response
-  const promise = sdk.postQuery()
+  const promise = sdk.runQuery()
   return expect(promise).rejects.toThrow()
 })
 
-test('e2e test getQuery API Success', () => {
+test('e2e test runPersistedQuery API Success', () => {
   // check success response
-  const promise = sdk.getQuery(persistedName)
+  const promise = sdk.runPersistedQuery(persistedName)
   return expect(promise).resolves.toBeTruthy()
 })
 
-test('e2e test getQuery API Error', () => {
+test('e2e test runPersistedQuery API Error', () => {
   // check error response
-  const promise = sdk.getQuery('/test')
+  const promise = sdk.runPersistedQuery('/test')
   return expect(promise).rejects.toThrow()
 })

--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "version": "1.0.1"
+  "version": "2.0.0"
 }

--- a/src/main.js
+++ b/src/main.js
@@ -42,7 +42,7 @@ class AEMHeadless {
    * @param {object} [options={}] - additional POST request options
    * @returns {Promise<any>} - the response body wrapped inside a Promise
    */
-  postQuery (query, options = {}) {
+  runQuery (query, options = {}) {
     return this.__handleRequest(this.endpoint, JSON.stringify({ query }), options)
   }
 
@@ -54,7 +54,7 @@ class AEMHeadless {
    * @param {object} [options={}] - additional PUT request options
    * @returns {Promise<any>} - the response body wrapped inside a Promise
    */
-  saveQuery (query, endpoint, options = {}) {
+  persistQuery (query, endpoint, options = {}) {
     const url = `${AEM_GRAPHQL_ACTIONS.persist}/${endpoint}`
     return this.__handleRequest(url, query, { method: 'PUT', ...options })
   }
@@ -65,7 +65,7 @@ class AEMHeadless {
    * @param {object} [options={}] - additional GET request options
    * @returns {Promise<any>} - the response body wrapped inside a Promise
    */
-  listQueries (options = {}) {
+  listPersistedQueries (options = {}) {
     const url = `${AEM_GRAPHQL_ACTIONS.list}`
     return this.__handleRequest(url, '', { method: 'GET', ...options })
   }
@@ -77,7 +77,7 @@ class AEMHeadless {
    * @param {object} [options={}] - additional GET request options
    * @returns {Promise<any>} - the response body wrapped inside a Promise
    */
-  getQuery (endpoint, options = {}) {
+  runPersistedQuery (endpoint, options = {}) {
     const url = `${AEM_GRAPHQL_ACTIONS.execute}/${endpoint}`
     return this.__handleRequest(url, '', { method: 'GET', ...options })
   }

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ class AEMHeadless {
    *
    * @param {object|string} config Configuration object, or AEM server URL string
    * @param {string} [config.serviceURL] AEM server URL
-   * @param {string} [config.endpoint] GraphQL endpoint, full URL or absolute path
+   * @param {string} [config.endpoint] GraphQL endpoint
    * @param {string|Array} [config.auth] Bearer token string or [user,pass] pair array
    */
   constructor (config) {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,7 +1,8 @@
 const AEM_GRAPHQL_ACTIONS = {
   persist: 'graphql/persist.json',
   execute: 'graphql/execute.json',
-  list: 'graphql/list.json'
+  list: 'graphql/list.json',
+  endpoint: 'content/graphql/global/endpoint.json'
 }
 
 module.exports = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,52 +41,52 @@ beforeEach(() => {
   })
 })
 
-test('saveQuery API Success', () => {
+test('persistQuery API Success', () => {
   // check success response
-  const promise = sdk.saveQuery(queryString, `${persistedName}-${Date.now()}`)
+  const promise = sdk.persistQuery(queryString, `${persistedName}-${Date.now()}`)
   return expect(promise).resolves.toBeTruthy()
 })
 
-test('saveQuery API Error', () => {
+test('persistQuery API Error', () => {
   fetch.mockRejectedValue({
     ok: false
   })
   // check error response
-  const promise = sdk.saveQuery(queryString, persistedName)
+  const promise = sdk.persistQuery(queryString, persistedName)
   return expect(promise).rejects.toThrow()
 })
 
-test('listQueries API Success', () => {
-  const promise = sdk.listQueries()
+test('listPersistedQueries API Success', () => {
+  const promise = sdk.listPersistedQueries()
   return expect(promise).resolves.toBeTruthy()
 })
 
-test('postQuery API Success', () => {
+test('runQuery API Success', () => {
   // check success response
-  const promise = sdk.postQuery(queryString)
+  const promise = sdk.runQuery(queryString)
   return expect(promise).resolves.toBeTruthy()
 })
 
-test('postQuery API Error', () => {
+test('runQuery API Error', () => {
   fetch.mockRejectedValue({
     ok: false
   })
   // check error response
-  const promise = sdk.postQuery()
+  const promise = sdk.runQuery()
   return expect(promise).rejects.toThrow()
 })
 
-test('getQuery API Success', () => {
+test('runPersistedQuery API Success', () => {
   // check success response
-  const promise = sdk.getQuery(persistedName)
+  const promise = sdk.runPersistedQuery(persistedName)
   return expect(promise).resolves.toBeTruthy()
 })
 
-test('getQuery API Error', () => {
+test('runPersistedQuery API Error', () => {
   fetch.mockRejectedValue({
     ok: false
   })
   // check error response
-  const promise = sdk.getQuery('/test')
+  const promise = sdk.runPersistedQuery('/test')
   return expect(promise).rejects.toThrow()
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,11 +26,13 @@ const queryString = `
 const persistedName = 'wknd/persist-query-name'
 let sdk = {}
 
-beforeAll(() => {
-  sdk = new AEMHeadless('endpoint/path.gql', 'http://localhost', ['user', 'pass'])
-})
-
 beforeEach(() => {
+  sdk = new AEMHeadless({
+    endpoint: 'endpoint/path.gql',
+    serviceURL: 'http://localhost',
+    auth: ['user', 'pass']
+  })
+
   fetch.resetMocks()
   fetch.mockResolvedValue({
     ok: true,
@@ -39,6 +41,30 @@ beforeEach(() => {
       data
     })
   })
+})
+
+test('sdk valid params', () => {
+  // check success response
+  const config = { serviceURL: 'test', auth: 'test' }
+  sdk = new AEMHeadless(config)
+  expect(sdk).toHaveProperty('serviceURL')
+  expect(sdk).toHaveProperty('endpoint')
+})
+
+test('sdk missing params', () => {
+  // check success response
+  const config = {}
+  sdk = new AEMHeadless(config)
+  expect(sdk).toHaveProperty('serviceURL')
+  expect(sdk).toHaveProperty('endpoint')
+})
+
+test('sdk missing param serviceURL', () => {
+  // check success response
+  const config = { endpoint: 'test' }
+  sdk = new AEMHeadless(config)
+  expect(sdk).toHaveProperty('serviceURL')
+  expect(sdk).toHaveProperty('endpoint')
 })
 
 test('persistQuery API Success', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Methods renamed:

new AEMHeadless(config)
  .runQuery(query, [options]) ⇒ Promise.<any>
  .persistQuery(query, path, [options]) ⇒ Promise.<any>
  .listPersistedQueries([options]) ⇒ Promise.<any>
  .runPersistedQuery(path, [options]) ⇒ Promise.<any>

Constructor updated:

<h3 style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(201, 209, 217); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">new AEMHeadless(config)</h3><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(201, 209, 217); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Constructor. If param is a string, it's treated as AEM server URL, default GraphQL endpoint is used. For granular params, use config object</p>

Param | Type | Description
-- | -- | --
config | object \| string | Configuration object, or AEM server URL string
[config.serviceURL] | string | AEM server URL
[config.endpoint] | string | GraphQL endpoint
[config.auth] | string \| Array | Bearer token string or [user,pass] pair array

<p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(201, 209, 217); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><a name="user-content-aemheadless+runquery" style="box-sizing: border-box; background-color: initial; color: inherit; text-decoration: none;"></a></p><h3 style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(201, 209, 217); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><a id="user-content-aemheadlessrunqueryquery-options--promiseany" class="anchor" aria-hidden="true" href="https://github.com/adobe/aem-headless-client-js/blob/feature/12-rename-methods/api-reference.md#aemheadlessrunqueryquery-options--promiseany" style="box-sizing: border-box; background-color: initial; color: var(--color-text-link); text-decoration: none; float: left; padding-right: 4px; margin-left: -20px; line-height: 1;"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a></h3><br class="Apple-interchange-newline">


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/adobe/aem-headless-client-js/issues/12

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
