### PR TITLE
fix(runPersistedQuery): handle multiple variables

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ class AEMHeadless {
   async runPersistedQuery (path, variables = {}, options = {}) {
     const method = (options.method || 'GET').toUpperCase()
     let body = ''
-    let variablesString = Object.keys(variables).map(key => `;${key}=${encodeURIComponent(variables[key])}`).join()
+    let variablesString = encodeURIComponent(Object.keys(variables).map(key => `;${key}=${(variables[key])}`).join(''))
 
     if (method === 'POST') {
       body = JSON.stringify({ variables })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
runPersistedQuery is not being able to handle multiple variables.
The resulting variablesString in actual code causes a ServletError when persisted queries with more than one variable are requested via the HTTP GET method.

## Description
<!--- Describe your changes in detail -->
Wrapping the result of the existing map function with encoencodeURIComponent instead of applying it to each variable, and specifying an empty string as separator in the method Array.prototype.join() makes variableString works in all scenarios and solves the problem.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> https://github.com/adobe/aem-headless-client-js/issues/28#issue-1071753352

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It is required in order to make the runPersistedQuery work with multiple variables.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
How changes were tested:
I persist a query with more than one variable
I called runPersistedQuery with a valid path and more than one variable in the parameters
No more errors were thrown by __handleRequest
No other code areas were affected


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.