### PR TITLE
#37 add support for variables

### DIFF
--- a/api-reference.md
+++ b/api-reference.md
@@ -22,7 +22,7 @@ with GraphQL endpoint, GraphQL serviceURL and auth if needed
 
 * [AEMHeadless](#AEMHeadless)
     * [new AEMHeadless(config)](#new_AEMHeadless_new)
-    * [.runQuery(query, [options], [retryOptions])](#AEMHeadless+runQuery) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.runQuery(body, [options], [retryOptions])](#AEMHeadless+runQuery) ⇒ <code>Promise.&lt;any&gt;</code>
     * [.persistQuery(query, path, [options], [retryOptions])](#AEMHeadless+persistQuery) ⇒ <code>Promise.&lt;any&gt;</code>
     * [.listPersistedQueries([options], [retryOptions])](#AEMHeadless+listPersistedQueries) ⇒ <code>Promise.&lt;any&gt;</code>
     * [.runPersistedQuery(path, [variables], [options], [retryOptions])](#AEMHeadless+runPersistedQuery) ⇒ <code>Promise.&lt;any&gt;</code>
@@ -65,7 +65,7 @@ For granular params, use config object
 
 <a name="AEMHeadless+runQuery"></a>
 
-### aemHeadless.runQuery(query, [options], [retryOptions]) ⇒ <code>Promise.&lt;any&gt;</code>
+### aemHeadless.runQuery(body, [options], [retryOptions]) ⇒ <code>Promise.&lt;any&gt;</code>
 Returns a Promise that resolves with a POST request JSON data.
 
 **Kind**: instance method of [<code>AEMHeadless</code>](#AEMHeadless)  
@@ -78,7 +78,7 @@ Returns a Promise that resolves with a POST request JSON data.
   </thead>
   <tbody>
 <tr>
-    <td>query</td><td><code>string</code></td><td></td><td><p>the query string</p>
+    <td>body</td><td><code>string</code> | <code>object</code></td><td></td><td><p>the query string or an object with query (and optionally variables) as a property</p>
 </td>
     </tr><tr>
     <td>[options]</td><td><code>object</code></td><td><code>{}</code></td><td><p>additional POST request options</p>

--- a/src/index.js
+++ b/src/index.js
@@ -59,15 +59,15 @@ class AEMHeadless {
    * @returns {Promise<any>} - the response body wrapped inside a Promise
    */
   async runQuery (body, options = {}, retryOptions = {}) {
-    let postBody = body
+    let postBody = { query: body }
     if (typeof body === 'object') {
       const { query, variables } = body
-      postBody = JSON.stringify({
+      postBody = {
         ...query ? { query } : {},
         ...variables ? { variables } : {}
-      })
+      }
     }
-    return this.__handleRequest(this.endpoint, postBody, options, retryOptions)
+    return this.__handleRequest(this.endpoint, JSON.stringify(postBody), options, retryOptions)
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -53,13 +53,21 @@ class AEMHeadless {
   /**
    * Returns a Promise that resolves with a POST request JSON data.
    *
-   * @param {string} query - the query string
+   * @param {string|object} body - the query string or an object with query (and optionally variables) as a property
    * @param {object} [options={}] - additional POST request options
    * @param {object} [retryOptions={}] - retry options for @adobe/aio-lib-core-networking
    * @returns {Promise<any>} - the response body wrapped inside a Promise
    */
-  async runQuery (query, options = {}, retryOptions = {}) {
-    return this.__handleRequest(this.endpoint, JSON.stringify({ query }), options, retryOptions)
+  async runQuery (body, options = {}, retryOptions = {}) {
+    let postBody = body
+    if (typeof body === 'object') {
+      const { query, variables } = body
+      postBody = JSON.stringify({
+        ...query ? { query } : {},
+        ...variables ? { variables } : {}
+      })
+    }
+    return this.__handleRequest(this.endpoint, postBody, options, retryOptions)
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -59,14 +59,7 @@ class AEMHeadless {
    * @returns {Promise<any>} - the response body wrapped inside a Promise
    */
   async runQuery (body, options = {}, retryOptions = {}) {
-    let postBody = { query: body }
-    if (typeof body === 'object') {
-      const { query, variables } = body
-      postBody = {
-        ...query ? { query } : {},
-        ...variables ? { variables } : {}
-      }
-    }
+    const postBody = typeof body === 'object' ? body : { query: body }
     return this.__handleRequest(this.endpoint, JSON.stringify(postBody), options, retryOptions)
   }
 

--- a/test/shared/index.test.js
+++ b/test/shared/index.test.js
@@ -76,6 +76,12 @@ test('API: runQuery API Success', () => {
   return expect(promise).resolves.toBeTruthy()
 })
 
+test('API: runQuery with variables API Success', () => {
+  // check success response
+  const promise = sdk.runQuery({ query: queryString, variables: { name: 'Ado' } })
+  return expect(promise).resolves.toBeTruthy()
+})
+
 test('API: runQuery API Error', () => {
   fetch.mockRejectedValue({
     ok: false
@@ -173,6 +179,13 @@ test('API: additional request options', () => {
   sdk = new AEMHeadless(config)
   const promise = sdk.runQuery(queryString, { method: 'GET' })
   return expect(promise).resolves.toStrictEqual({ data: 'test' })
+})
+
+test('API: runQuery with custom headers API Success', () => {
+  const config = { headers: { 'global-header': 'global-value' } }
+  sdk = new AEMHeadless(config)
+  const promise = sdk.runQuery(queryString, { headers: { 'custom-header': 'custom-value' } })
+  return expect(promise).resolves.toBeTruthy()
 })
 
 test('API: params validation', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add variables support in runQuery mehod.
```
   /*
   * @param {string|object} body - the query string **or an object with query (and optionally variables) as a property**
   */
  async runQuery (body, options = {}, retryOptions = {})
```
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #37 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
