### PR TITLE
fix: #51 persisted query string parameter encoding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ class AEMHeadless {
     const method = (options.method || 'GET').toUpperCase()
     let body = ''
     let variablesString = encodeURIComponent(Object.keys(variables).map(key => {
-      const val = JSON.stringify(variables[key])
+      const val = (typeof variables[key] === 'string') ? variables[key] : JSON.stringify(variables[key])
       return `;${key}=${val}`
     }).join(''))
 

--- a/test/shared/index.test.js
+++ b/test/shared/index.test.js
@@ -103,6 +103,13 @@ test('API: runPersistedQuery with variables API Success', () => {
   return expect(promise).resolves.toBeTruthy()
 })
 
+test('API: runPersistedQuery GET with variables API Success', () => {
+  // check success response
+  const promise = sdk.runPersistedQuery(persistedName, { name: 'test' })
+  expect(fetch).toHaveBeenCalledWith(`http://localhost/graphql/execute.json/${persistedName}%3Bname%3Dtest`, expect.anything(), expect.anything())
+  return expect(promise).resolves.toBeTruthy()
+})
+
 test('API: runPersistedQuery API Error', () => {
   fetch.mockRejectedValue({
     ok: false


### PR DESCRIPTION
Fixes a problem where persisted query string parameters are not being properly encoded 

## Description

`JSON.stringify` is used to coerce objects into string parameters.  When it's used on a string, the value is quoted adding some additional, unexpected characters to the encoded url.

For example, where the parameter `name: test` is provided, then it is output in the url as:
* `http://localhost/graphql/execute.json/wknd/persist-query-name%3Bname%3D%22test%22` (url encoded)
* `http://localhost/graphql/execute.json/wknd/persist-query-name;name="test"` (unencoded)
instead of:
* `http://localhost/graphql/execute.json/wknd/persist-query-name%3Bname%3Dtest` (url encoded)
* `http://localhost/graphql/execute.json/wknd/persist-query-name;name=test` (unencoded) 

## Related Issue
#49, #51
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Added a unit test that failed with simple key=value parameters by verifying the url passed to fetch.  Test passes with small change to the runPersistedQuery function that checks the `val` type before using `JSON.stringify(...)`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
