### PR TITLE
fix: #61 failing requests for queries with multiple parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ class AEMHeadless {
       return `;${key}=${val}`
     }).join(''))
 
-    if (method === 'GET') {
+    if (method === 'GET' && variablesString) {
       variablesString += ';'
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,6 @@ class AEMHeadless {
     }).join(''))
 
     if (method === 'GET') {
-      // https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/headless/graphql-api/content-fragments#dynamic-image-delivery-multiple-specified-parameters
       variablesString += variablesString + ';';
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ class AEMHeadless {
     }).join(''))
 
     if (method === 'GET') {
-      variablesString += variablesString + ';'
+      variablesString += ';'
     }
 
     if (method === 'POST') {

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,11 @@ class AEMHeadless {
       return `;${key}=${val}`
     }).join(''))
 
+    if (method === 'GET') {
+      // https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/headless/graphql-api/content-fragments#dynamic-image-delivery-multiple-specified-parameters
+      variablesString += variablesString + ';';
+    }
+
     if (method === 'POST') {
       body = JSON.stringify({ variables })
       variablesString = ''

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ class AEMHeadless {
     }).join(''))
 
     if (method === 'GET') {
-      variablesString += variablesString + ';';
+      variablesString += variablesString + ';'
     }
 
     if (method === 'POST') {

--- a/test/shared/index.test.js
+++ b/test/shared/index.test.js
@@ -117,6 +117,19 @@ test('API: runPersistedQuery GET with two variables API Success', () => {
   return expect(promise).resolves.toBeTruthy()
 })
 
+test('API: runPersistedQuery GET with no variables API Success', () => {
+  // check success response
+  const promise = sdk.runPersistedQuery(persistedName)
+  expect(fetch).toHaveBeenCalledWith(`http://localhost/graphql/execute.json/${persistedName}`, expect.anything(), expect.anything())
+  return expect(promise).resolves.toBeTruthy()
+})
+
+test('API: runPersistedQuery GET with no variables API Success and empty variables', () => {
+  const promise = sdk.runPersistedQuery(persistedName, {})
+  expect(fetch).toHaveBeenCalledWith(`http://localhost/graphql/execute.json/${persistedName}`, expect.anything(), expect.anything())
+  return expect(promise).resolves.toBeTruthy()
+})
+
 test('API: runPersistedQuery API Error', () => {
   fetch.mockRejectedValue({
     ok: false

--- a/test/shared/index.test.js
+++ b/test/shared/index.test.js
@@ -110,6 +110,13 @@ test('API: runPersistedQuery GET with variables API Success', () => {
   return expect(promise).resolves.toBeTruthy()
 })
 
+test('API: runPersistedQuery GET with two variables API Success', () => {
+  // check success response
+  const promise = sdk.runPersistedQuery(persistedName, { name: 'test', locale: 'en' })
+  expect(fetch).toHaveBeenCalledWith(`http://localhost/graphql/execute.json/${persistedName}%3Bname%3Dtest%3locale%3en;`, expect.anything(), expect.anything())
+  return expect(promise).resolves.toBeTruthy()
+})
+
 test('API: runPersistedQuery API Error', () => {
   fetch.mockRejectedValue({
     ok: false

--- a/test/shared/index.test.js
+++ b/test/shared/index.test.js
@@ -106,14 +106,14 @@ test('API: runPersistedQuery with variables API Success', () => {
 test('API: runPersistedQuery GET with variables API Success', () => {
   // check success response
   const promise = sdk.runPersistedQuery(persistedName, { name: 'test' })
-  expect(fetch).toHaveBeenCalledWith(`http://localhost/graphql/execute.json/${persistedName}%3Bname%3Dtest`, expect.anything(), expect.anything())
+  expect(fetch).toHaveBeenCalledWith(`http://localhost/graphql/execute.json/${persistedName}%3Bname%3Dtest;`, expect.anything(), expect.anything())
   return expect(promise).resolves.toBeTruthy()
 })
 
 test('API: runPersistedQuery GET with two variables API Success', () => {
   // check success response
   const promise = sdk.runPersistedQuery(persistedName, { name: 'test', locale: 'en' })
-  expect(fetch).toHaveBeenCalledWith(`http://localhost/graphql/execute.json/${persistedName}%3Bname%3Dtest%3locale%3en;`, expect.anything(), expect.anything())
+  expect(fetch).toHaveBeenCalledWith(`http://localhost/graphql/execute.json/${persistedName}%3Bname%3Dtest%3Blocale%3Den;`, expect.anything(), expect.anything())
   return expect(promise).resolves.toBeTruthy()
 })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #61 
The current implementation is not reflecting the documented behaviour: https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/headless/graphql-api/content-fragments#dynamic-image-delivery-multiple-specified-parameters

- [x] Run tests fully as there is no description in the contribution guide on how to test this in local or test data provided to setup the GraphQL data and run the client against an endpoint.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This fixes the issue you run into when running a persistedQuery containing two parameters in the GET request.

## How Has This Been Tested?

Unit test has been added, but example project on AEM side needs to be extended with a query supporting at least 2 parameters in order to test it fully.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. ❓ 
